### PR TITLE
Fixed syntax error in README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Exception notification must be set up in your Rails config files. In general, yo
       # Other configuration here, including ActionMailer config ...
 
       config.middleware.use ExceptionNotification::Rack,
-	    :ignore_if => lambda { |env, exception| !env[:rake?] }
+	    :ignore_if => lambda { |env, exception| !env[:rake?] },
         :email => {
           :sender_address => %{"notifier" <sender.address@example.com>},
           :exception_recipients => %w{your.email@example.com}


### PR DESCRIPTION
A missing comma in the minimal configuration example results in a syntax error. This commit fixes the problem by adding the comma.
