### PR TITLE
Set `sections` option by default

### DIFF
--- a/lib/exception_notifier/rake/rake.rb
+++ b/lib/exception_notifier/rake/rake.rb
@@ -38,6 +38,7 @@ module ExceptionNotifier
 
     def self.default_notifier_options
       {
+        :sections => %w(rake backtrace),
         :background_sections => %w(rake backtrace),
         :env => {:rake? => true},
       }


### PR DESCRIPTION
It would be better to set both `sections` and `background_sections` by default.
Otherwise, we get error in `Request` section when processing as a normal notification.
