### PR TITLE
Require exception_notification gem to prevent NameError

### DIFF
--- a/lib/exception_notification/rake.rb
+++ b/lib/exception_notification/rake.rb
@@ -1,2 +1,3 @@
 # This file exists to support gem autoloading by bundler.
+require 'exception_notification'
 require 'exception_notifier/rake'


### PR DESCRIPTION
The following error occurs if we don't load `exception_notification` gem manually. So It would be good to load automatically.

```
rake aborted!
NameError: uninitialized constant ExceptionNotification
/path/to/sample_rails4/config/environments/development.rb:40:in `block in <top (required)>'
/path/to/vendor/bundle/gems/railties-4.1.2/lib/rails/railtie.rb:210:in `instance_eval'
/path/to/vendor/bundle/gems/railties-4.1.2/lib/rails/railtie.rb:210:in `configure'
/path/to/sample_rails4/config/environments/development.rb:2:in `<top (required)>'
/path/to/vendor/bundle/gems/railties-4.1.2/lib/rails/engine.rb:594:in `block (2 levels) in <class:Engine>'
/path/to/vendor/bundle/gems/railties-4.1.2/lib/rails/engine.rb:593:in `each'
/path/to/vendor/bundle/gems/railties-4.1.2/lib/rails/engine.rb:593:in `block in <class:Engine>'
/path/to/vendor/bundle/gems/railties-4.1.2/lib/rails/initializable.rb:30:in `instance_exec'
/path/to/vendor/bundle/gems/railties-4.1.2/lib/rails/initializable.rb:30:in `run'
/path/to/vendor/bundle/gems/railties-4.1.2/lib/rails/initializable.rb:55:in `block in run_initializers'
/path/to/vendor/bundle/gems/railties-4.1.2/lib/rails/initializable.rb:44:in `each'
/path/to/vendor/bundle/gems/railties-4.1.2/lib/rails/initializable.rb:44:in `tsort_each_child'
/path/to/vendor/bundle/gems/railties-4.1.2/lib/rails/initializable.rb:54:in `run_initializers'
/path/to/vendor/bundle/gems/railties-4.1.2/lib/rails/application.rb:300:in `initialize!'
/path/to/sample_rails4/config/environment.rb:5:in `<top (required)>'
/path/to/vendor/bundle/gems/railties-4.1.2/lib/rails/application.rb:276:in `require_environment!'
/path/to/vendor/bundle/gems/railties-4.1.2/lib/rails/application.rb:379:in `block in run_tasks_blocks'
```
