### PR TITLE
Make it compatible with Rollbar gem's rake patch

### DIFF
--- a/lib/exception_notifier/rake/rake_patch.rb
+++ b/lib/exception_notifier/rake/rake_patch.rb
@@ -9,11 +9,11 @@ module ExceptionNotifier
           ExceptionNotifier::Rake.maybe_deliver_notification(ex,
             :rake_command_line => reconstruct_command_line)
         end
-      end
-    end
 
-    def reconstruct_command_line
-      "rake #{ARGV.join(' ')}"
+        def reconstruct_command_line
+          "rake #{ARGV.join(' ')}"
+        end
+      end
     end
   end
 end

--- a/lib/exception_notifier/rake/rake_patch.rb
+++ b/lib/exception_notifier/rake/rake_patch.rb
@@ -1,18 +1,15 @@
-# Monkey patching patterns lifted from
-# https://github.com/thoughtbot/airbrake/blob/master/lib/airbrake/rake_handler.rb
 module ExceptionNotifier
   module RakePatch
-    def self.included(klass)
-      klass.class_eval do
+    def self.patch!
+      ::Rake::Application.class_eval do
         alias_method :display_error_message_without_notifications, :display_error_message
-        alias_method :display_error_message, :display_error_message_with_notifications
-      end
-    end
 
-    def display_error_message_with_notifications(ex)
-      display_error_message_without_notifications(ex)
-      ExceptionNotifier::Rake.maybe_deliver_notification(ex,
-        :rake_command_line => reconstruct_command_line)
+        def display_error_message(ex)
+          display_error_message_without_notifications(ex)
+          ExceptionNotifier::Rake.maybe_deliver_notification(ex,
+            :rake_command_line => reconstruct_command_line)
+        end
+      end
     end
 
     def reconstruct_command_line
@@ -24,9 +21,5 @@ end
 # Only do this if we're actually in a Rake context. In some contexts (e.g.,
 # in the Rails console) Rake might not be defined.
 if Object.const_defined? :Rake
-  Rake.application.instance_eval do
-    class << self
-      include ExceptionNotifier::RakePatch
-    end
-  end
+  ExceptionNotifier::RakePatch.patch!
 end


### PR DESCRIPTION
When exception_notification-rake and rollbar-gem are both used, notifications about exceptions in rake tasks don't get sent to Rollbar.