### PR TITLE
Fix error exposed by running rspec in RubyMine

### DIFF
--- a/lib/exception_notifier/rake/rake_patch.rb
+++ b/lib/exception_notifier/rake/rake_patch.rb
@@ -23,7 +23,7 @@ end
 
 # Only do this if we're actually in a Rake context. In some contexts (e.g.,
 # in the Rails console) Rake might not be defined.
-if Object.const_defined? :Rake
+if Object.const_defined?(:Rake) && Rake.respond_to?(:application)
   Rake.application.instance_eval do
     class << self
       include ExceptionNotifier::RakePatch


### PR DESCRIPTION
[https://github.com/nikhaldi/exception_notification-rake/issues/14](Not working with Rubymine 11 Testing #14) - I was having the same error in RubyMine 8. Testing to see if `Rake` responds_to `:application` fixed it.
