### PR TITLE
Works with Rails 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This Ruby gem is an extension of the [exception_notification gem](http://rubygem
 
 ## Installation
 
-If you're using Rails 4.2 or higher, including Rails 5 (or you're not using Rails at all), use the latest version of the gem:
+If you're using Rails 4.2 or higher, including Rails 5 and 6 (or you're not using Rails at all), use the latest version of the gem:
 
     gem 'exception_notification-rake', '~> 0.3.0'
 

--- a/lib/exception_notifier/rake/version.rb
+++ b/lib/exception_notifier/rake/version.rb
@@ -1,5 +1,5 @@
 module ExceptionNotifier
   class Rake
-    VERSION = '0.3.0'
+    VERSION = '0.3.1'
   end
 end


### PR DESCRIPTION
Commit from May (https://github.com/nikhaldi/exception_notification-rake/commit/d0412f4c11d00e55a89dc2636a35feb15b6e56c0) already supports `exception_notification` 4.4 which changed its dependencies from`activesupport (>= 4.0, < 6)` to `activesupport (>= 4.0, < 7)`.

So `master` branch already works fine with Rails 6. I tested in my app and got an email after raising an error in a rake task.

Updated the version number since there hasn't been a gem release since January 2017. (https://rubygems.org/gems/exception_notification-rake)